### PR TITLE
removes the need to build by adding a prepare script

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "clean:dist": "rm -Rrf ./dist",
     "clean": "del ./dist",
     "build:jsdoc": "node node_modules/jsdoc/jsdoc.js -d jsdoc src/helpers/* -R src/docs/jsdoc_home.md",
-    "lint": "prettier --check 'src/**/*.js'"
+    "lint": "prettier --check 'src/**/*.js'",
+    "prepare": "rollup -c build/rollup.config.js"
   },
   "main": "dist/src/index.js",
   "module": "dist/src/index.js",


### PR DESCRIPTION
This adds a prepare phase to our build process that automatically runs the rollup build  (so we don't have to remember to)