### PR TITLE
update devops orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ anchors:
       at: *workspace_root
 
 orbs:
-  getty-devops: thegetty/devops-orb@2
+  getty-devops: thegetty/devops-orb@3
 
 jobs:
   build:


### PR DESCRIPTION
we need to update the DevOps Orb for all of our apps to v3.  This does two things:
1. it changes the authentication model to improve security
2. it allows for different kubernetes repositories