### PR TITLE
Adding Duschamp tests 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 
 - `Removed`: for deprecated features removed in this release
 
+## [0.19.0]
+
+### Added
+
+- added a few more examples of LinkedArt data from the PMA
+
+### Changed
+
+- adjusted the logic around 'getPrimaryName' to fallback to `Name` entries when a qualified name isn't used and no qualification is entered
+
 ## [0.18.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thegetty/linkedart.js",
-  "version": "0.17.2",
+  "version": "0.19.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thegetty/linkedart.js",
-      "version": "0.17.2",
+      "version": "0.19.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@babel/core": "7.20.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/linkedart.js",
-  "version": "0.17.2",
+  "version": "0.19.0",
   "keywords": [
     "LinkedArt",
     "Linked Art",

--- a/src/data/mocks/duschamp.json
+++ b/src/data/mocks/duschamp.json
@@ -1,0 +1,205 @@
+{
+    "@context": "https://linked.art/ns/v1/linked-art.json",
+    "about": [],
+    "classified_as": [
+        {
+            "id": "http://data.duchamparchives.org/cp/object/thesaurus/dessin",
+            "label": [
+                {
+                    "@language": "fr",
+                    "@value": "dessins"
+                },
+                "Dessin"
+            ],
+            "type": "Type"
+        },
+        {
+            "id": "aat:300133025",
+            "label": [
+                {
+                    "@language": "en",
+                    "@value": "works of art"
+                },
+                "works of art"
+            ],
+            "type": "Type"
+        }
+    ],
+    "crm:P104_is_subject_to": null,
+    "crm:P57_has_number_of_parts": null,
+    "current_keeper": null,
+    "current_location": null,
+    "current_owner": [
+        {
+            "id": "http://data.duchamparchives.org/pompidou",
+            "label": "Centre Pompidou",
+            "type": "Group"
+        }
+    ],
+    "depicts": [],
+    "id": "http://data.duchamparchives.org/cp/object/150000000076631",
+    "identified_by": [
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300404670",
+                    "label": "preferred terms",
+                    "type": "Type"
+                },
+                {
+                    "id": "aat:300404621",
+                    "label": "repository numbers",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/cp/object/150000000076631/object_id",
+            "type": "Identifier",
+            "value": "150000000076631"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300312355",
+                    "label": "accession numbers",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/cp/object/150000000076631/accession",
+            "type": "Identifier",
+            "value": "AM 1997-98 (163)"
+        },
+        {
+            "id": "http://data.duchamparchives.org/cp/object/150000000076631/title",
+            "type": "Name",
+            "value": "1 l'intention/2 la crainte/3 d\u00e9sir"
+        }
+    ],
+    "label": null,
+    "language": [],
+    "made_of": [],
+    "ore:isAggregatedBy": null,
+    "part_of": [],
+    "produced_by": {
+        "carried_out_by": [
+            "http://data.duchamparchives.org/pma/archive/actor/LCNAF/n80057220"
+        ],
+        "consists_of": [
+            {
+                "carried_out_by": [
+                    {
+                        "id": "http://data.duchamparchives.org/pma/archive/actor/LCNAF/n80057220",
+                        "label": "Duchamp, Marcel, 1887-1968",
+                        "type": "Actor"
+                    }
+                ],
+                "classified_as": [],
+                "id": "http://data.duchamparchives.org/cp/object/150000000076631/production/artiste",
+                "technique": [
+                    {
+                        "id": "aat:artist",
+                        "label": "artist",
+                        "type": "Type"
+                    }
+                ],
+                "type": "Production"
+            }
+        ],
+        "id": "http://data.duchamparchives.org/cp/object/150000000076631/production",
+        "timespan": {
+            "begin_of_the_begin": "1912-01-01T00:00:00.000Z",
+            "end_of_the_end": "1968-01-01T00:00:00.000Z",
+            "id": "http://data.duchamparchives.org/cp/object/150000000076631/production/timespan",
+            "label": "1912 - 1968",
+            "type": "TimeSpan"
+        },
+        "type": "Production"
+    },
+    "referred_to_by": [
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300026687",
+                    "label": "acknowledgments",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/cp/object/150000000076631/credit",
+            "type": "LinguisticObject",
+            "value": "Dation, 1997"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300028702",
+                    "label": [
+                        "inscriptions",
+                        {
+                            "@language": "en",
+                            "@value": "inscriptions"
+                        }
+                    ],
+                    "type": "Type"
+                }
+            ],
+            "type": "LinguisticObject",
+            "value": "Transcription :\n1 l\u2019intention\t  3 d\u00e9sir\n2 la crainte\n\nCentres d\u00e9sir au nombre de 3.\nContiennent une mati\u00e8re\nanalogue \u00e0 la mousse de\nplatine = lente \u00e0 s\u2019allumer."
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300055547",
+                    "label": "legal concepts",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/cp/object/150000000076631/rights",
+            "type": "LinguisticObject",
+            "value": "\u00a9 Association Marcel Duchamp / Adagp, Paris"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300080091",
+                    "label": "description (activity)",
+                    "type": "Type"
+                }
+            ],
+            "type": "LinguisticObject",
+            "value": "Ensemble de 289 notes originales de Marcel Duchamp. Notes publi\u00e9es en fac-simil\u00e9 par Paul Matisse dans \"Marcel Duchamp, Notes\" (Paris, Centre national d'art et de culture Georges Pompidou, 1980), r\u00e9parties en 4 sections : \"Inframince\", \"Le Grand Verre\", \"Projets\" et \"Jeux de mots\".\nentre 1912 et 1968"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300163343",
+                    "label": "media (artists' materials)",
+                    "type": "Type"
+                }
+            ],
+            "type": "LinguisticObject",
+            "value": "Mine graphite sur papier"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300266036",
+                    "label": "dimensions",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/cp/object/150000000076631/dimensions",
+            "type": "LinguisticObject",
+            "value": "20 x 15,8 cm"
+        }
+    ],
+    "refers_to": [],
+    "related": [],
+    "representation": [
+        {
+            "id": "https://iiif.duchamparchives.org/image/iiif/2/9000000064949",
+            "type": "VisualItem"
+        }
+    ],
+    "subject_of": [],
+    "type": "ManMadeObject",
+    "used_for": []
+}

--- a/src/data/mocks/duschamp2.json
+++ b/src/data/mocks/duschamp2.json
@@ -1,0 +1,215 @@
+{
+    "@context": "https://linked.art/ns/v1/linked-art.json",
+    "about": [],
+    "classified_as": [
+        {
+            "id": "aat:300133025",
+            "label": [
+                {
+                    "@language": "en",
+                    "@value": "works of art"
+                },
+                "works of art"
+            ],
+            "type": "Type"
+        },
+        {
+            "id": "aat:300047090",
+            "label": [
+                {
+                    "@language": "en",
+                    "@value": "sculpture/Readymades"
+                },
+                "sculpture (visual works)"
+            ],
+            "type": "Type"
+        }
+    ],
+    "crm:P104_is_subject_to": null,
+    "crm:P57_has_number_of_parts": null,
+    "current_keeper": null,
+    "current_location": null,
+    "current_owner": [
+        {
+            "id": "http://data.philamuseum.org",
+            "label": "Philadelphia Museum of Art",
+            "type": "Group"
+        }
+    ],
+    "depicts": [],
+    "id": "http://data.duchamparchives.org/pma/object/51617",
+    "identified_by": [
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300312355",
+                    "label": "accession numbers",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/pma/object/51617/object_number",
+            "type": "Identifier",
+            "value": "1950-134-78"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300404670",
+                    "label": "preferred terms",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/pma/object/51617/title/0",
+            "type": "Name",
+            "value": "50 cc of Paris Air"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300404670",
+                    "label": "preferred terms",
+                    "type": "Type"
+                },
+                {
+                    "id": "aat:300404621",
+                    "label": "repository numbers",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/pma/object/51617/id",
+            "type": "Identifier",
+            "value": "51617"
+        }
+    ],
+    "label": null,
+    "language": [],
+    "made_of": [],
+    "ore:isAggregatedBy": null,
+    "part_of": [],
+    "produced_by": {
+        "carried_out_by": [
+            "http://data.duchamparchives.org/pma/archive/actor/LCNAF/n80057220"
+        ],
+        "consists_of": [
+            {
+                "carried_out_by": [
+                    {
+                        "id": "http://data.duchamparchives.org/pma/archive/actor/LCNAF/n80057220",
+                        "label": "Duchamp, Marcel, 1887-1968",
+                        "type": "Actor"
+                    }
+                ],
+                "classified_as": [],
+                "id": "http://data.duchamparchives.org/pma/object/51617/production/0",
+                "technique": [
+                    {
+                        "id": "aat:300025103",
+                        "label": [
+                            {
+                                "@language": "en",
+                                "@value": "artist"
+                            },
+                            {
+                                "@language": "en",
+                                "@value": "artists (visual artists)"
+                            },
+                            "artists (visual artists)"
+                        ],
+                        "type": "Type"
+                    }
+                ],
+                "type": "Production"
+            }
+        ],
+        "id": "http://data.duchamparchives.org/pma/object/51617/production",
+        "timespan": {
+            "begin_of_the_begin": "1919-01-01T00:00:00.000Z",
+            "end_of_the_end": "1919-01-01T00:00:00.000Z",
+            "label": "1919",
+            "type": "TimeSpan"
+        },
+        "type": "Production"
+    },
+    "referred_to_by": [
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300026687",
+                    "label": "acknowledgments",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/pma/object/51617/credit",
+            "type": "LinguisticObject",
+            "value": "The Louise and Walter Arensberg Collection, 1950"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300055547",
+                    "label": "legal concepts",
+                    "type": "Type"
+                }
+            ],
+            "type": "LinguisticObject",
+            "value": "\u00a9 Artists Rights Society (ARS), New York / ADAGP, Paris / Succession Marcel Duchamp"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300080091",
+                    "label": "description (activity)",
+                    "type": "Type"
+                }
+            ],
+            "type": "LinguisticObject",
+            "value": "Duchamp purchased this \"empty\" ampoule from a pharmacist in Paris as a souvenir for his close friend and patron, Walter C. Arensberg. A vial with nothing in it may be the most insubstantial \"work of art\" imaginable. From a molecular point of view, air is not considered nothing, but when displayed so carefully in an art museum it seems to be less than one might expect. Its precise meaning was rendered even more unstable in 1949, when the ampoule was accidentally broken and repaired, thus begging the question: Is the air even from Paris anymore?"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300163343",
+                    "label": "media (artists' materials)",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/pma/object/51617/medium",
+            "type": "LinguisticObject",
+            "value": "Glass ampoule (broken and later restored)"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300266036",
+                    "label": "dimensions",
+                    "type": "Type"
+                }
+            ],
+            "id": "http://data.duchamparchives.org/pma/object/51617/dimensions",
+            "type": "LinguisticObject",
+            "value": "5 1/4 x 2 1/2 inches (13.3 \u00d7 6.4 cm)"
+        },
+        {
+            "classified_as": [
+                {
+                    "id": "aat:300054388",
+                    "label": "geography",
+                    "type": "Type"
+                }
+            ],
+            "type": "LinguisticObject",
+            "value": "Made in Paris, France, Europe"
+        }
+    ],
+    "refers_to": [],
+    "related": [],
+    "representation": [
+        {
+            "id": "https://iiif.duchamparchives.org/image/iiif/2/1950-134-78-pma2017",
+            "type": "VisualItem"
+        }
+    ],
+    "subject_of": [],
+    "type": "ManMadeObject",
+    "used_for": []
+}

--- a/src/helpers/LinkedArtHelpers.js
+++ b/src/helpers/LinkedArtHelpers.js
@@ -312,6 +312,15 @@ export function getPrimaryNames(
     return name;
   }
 
+  // if we don't have a name with a classification, and we're using the 'default' values, look for a Name
+  if (names.length > 0 && requestedClassifications == aat.PREFERRED_TERM) {
+    let values = [...names];
+    for (let i in values) {
+      values[i] = getValueOrContent(values[i]);
+    }
+    return values;
+  }
+
   // fallback for error case
   let label = UNKNOWN;
   if (submittedResource && submittedResource.id) {

--- a/src/specs/duschamp.spec.js
+++ b/src/specs/duschamp.spec.js
@@ -1,0 +1,113 @@
+import * as helpers from "../helpers/LinkedArtHelpers";
+import * as objectHelpers from "../helpers/ObjectHelpers";
+import duschamp from "../data/mocks/duschamp.json";
+import duschamp2 from "../data/mocks/duschamp2.json";
+
+describe("tests the duschamp record", () => {
+  it("gets the title", () => {
+    expect(helpers.getPrimaryName(duschamp)).toEqual(
+      "1 l'intention/2 la crainte/3 désir"
+    );
+  });
+  it("gets the accession #", () => {
+    expect(objectHelpers.getAccessionNumbers(duschamp)).toEqual([
+      "AM 1997-98 (163)",
+    ]);
+  });
+  it("gets the person who created it", () => {
+    expect(objectHelpers.getCarriedOutBy(duschamp)).toEqual([
+      "http://data.duchamparchives.org/pma/archive/actor/LCNAF/n80057220",
+    ]);
+  });
+  it("gets the creation date", () => {
+    expect(objectHelpers.getProductionTimespans(duschamp)).toEqual([
+      {
+        begin_of_the_begin: "1912-01-01T00:00:00.000Z",
+        end_of_the_end: "1968-01-01T00:00:00.000Z",
+        id: "http://data.duchamparchives.org/cp/object/150000000076631/production/timespan",
+        label: "1912 - 1968",
+        type: "TimeSpan",
+      },
+    ]);
+  });
+
+  it("gets the rights statement", () => {
+    expect(objectHelpers.getRightsStatements(duschamp)).toEqual([
+      "© Association Marcel Duchamp / Adagp, Paris",
+    ]);
+  });
+  it("gets the copyright statement", () => {
+    expect(objectHelpers.getCopyrightStatements(duschamp)).toEqual([]);
+  });
+  it("gets the dimensions", () => {
+    expect(
+      objectHelpers.getDimensionsDescriptions(duschamp, {
+        requestedClassifications: "aat:300266036",
+      })
+    ).toEqual(["20 x 15,8 cm"]);
+  });
+  it("gets the rights assertions", () => {
+    expect(objectHelpers.getRightsAssertions(duschamp)).toEqual([]);
+  });
+  it("gets the digital image", () => {
+    expect(objectHelpers.getDigitalImages(duschamp)).toEqual([]);
+  });
+  it("gets the descriptions", () => {
+    expect(helpers.getDescriptions(duschamp)).toEqual([
+      'Ensemble de 289 notes originales de Marcel Duchamp. Notes publiées en fac-similé par Paul Matisse dans "Marcel Duchamp, Notes" (Paris, Centre national d\'art et de culture Georges Pompidou, 1980), réparties en 4 sections : "Inframince", "Le Grand Verre", "Projets" et "Jeux de mots".\nentre 1912 et 1968',
+    ]);
+  });
+});
+
+describe("tests the duschamp record(2)", () => {
+  it("gets the title", () => {
+    expect(helpers.getPrimaryName(duschamp2)).toEqual("50 cc of Paris Air");
+  });
+  it("gets the accession #", () => {
+    expect(objectHelpers.getAccessionNumbers(duschamp2)).toEqual([
+      "1950-134-78",
+    ]);
+  });
+  it("gets the person who created it", () => {
+    expect(objectHelpers.getCarriedOutBy(duschamp2)).toEqual([
+      "http://data.duchamparchives.org/pma/archive/actor/LCNAF/n80057220",
+    ]);
+  });
+  it("gets the creation date", () => {
+    expect(objectHelpers.getProductionTimespans(duschamp2)).toEqual([
+      {
+        begin_of_the_begin: "1919-01-01T00:00:00.000Z",
+        end_of_the_end: "1919-01-01T00:00:00.000Z",
+        label: "1919",
+        type: "TimeSpan",
+      },
+    ]);
+  });
+
+  it("gets the rights statement", () => {
+    expect(objectHelpers.getRightsStatements(duschamp2)).toEqual([
+      "© Artists Rights Society (ARS), New York / ADAGP, Paris / Succession Marcel Duchamp",
+    ]);
+  });
+  it("gets the copyright statement", () => {
+    expect(objectHelpers.getCopyrightStatements(duschamp2)).toEqual([]);
+  });
+  it("gets the dimensions", () => {
+    expect(
+      objectHelpers.getDimensionsDescriptions(duschamp2, {
+        requestedClassifications: "aat:300266036",
+      })
+    ).toEqual(["5 1/4 x 2 1/2 inches (13.3 × 6.4 cm)"]);
+  });
+  it("gets the rights assertions", () => {
+    expect(objectHelpers.getRightsAssertions(duschamp2)).toEqual([]);
+  });
+  it("gets the digital image", () => {
+    expect(objectHelpers.getDigitalImages(duschamp2)).toEqual([]);
+  });
+  it("gets the descriptions", () => {
+    expect(helpers.getDescriptions(duschamp2)).toEqual([
+      'Duchamp purchased this "empty" ampoule from a pharmacist in Paris as a souvenir for his close friend and patron, Walter C. Arensberg. A vial with nothing in it may be the most insubstantial "work of art" imaginable. From a molecular point of view, air is not considered nothing, but when displayed so carefully in an art museum it seems to be less than one might expect. Its precise meaning was rendered even more unstable in 1949, when the ampoule was accidentally broken and repaired, thus begging the question: Is the air even from Paris anymore?',
+    ]);
+  });
+});


### PR DESCRIPTION
adds some test records fromm the Duschamp archives.  Through this, identified a few interesting challenges:

1. what to do with “Name” entries that are not qualified (addressed)
2. issues where `value` contains text vs. content
3. Arches style data entry with language qualifications:
```
            "classified_as": [
                {
                    "id": "aat:300028702",
                    "label": [
                        "inscriptions",
                        {
                            "https://github.com/language": "en",
                            "https://github.com/value": "inscriptions"
                        }
                    ],
                    "type": "Type"
                }
            ],
```
4. CIDOC prefixed values instead of the LinkedArt keys:
```
    "crm:P104_is_subject_to": null,
    "crm:P57_has_number_of_parts": null,
```