### PR TITLE
adjust attribution logic

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,12 @@ Project versions conform to [Semantic Versioning](https://semver.org/)
 
 - `Removed`: for deprecated features removed in this release
 
+## [0.20.0]
+
+### Changed
+
+- `attributed_by` does not require an `assigned_property` so adjusting the logic to allow for it to be null
+
 ## [0.19.0]
 
 ### Added

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@thegetty/linkedart.js",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@thegetty/linkedart.js",
-      "version": "0.19.0",
+      "version": "0.20.0",
       "license": "BSD-3-Clause",
       "devDependencies": {
         "@babel/core": "7.20.7",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@thegetty/linkedart.js",
-  "version": "0.19.0",
+  "version": "0.20.0",
   "keywords": [
     "LinkedArt",
     "Linked Art",

--- a/src/data/mocks/jpc.json
+++ b/src/data/mocks/jpc.json
@@ -1,0 +1,113 @@
+{
+    "@context": "https://linked.art/ns/v1/linked-art.json",
+    "_label": "Aiken, Kimberly - Box COI-001A Folder 047 Item 0008",
+    "assigned_by": [
+        {
+            "_label": "Related Media Sequence Assignment",
+            "assigned": [
+                {
+                    "_label": "Related Media Sequence",
+                    "classified_as": [
+                        {
+                            "_label": "sequences",
+                            "id": "http://vocab.getty.edu/aat/300192339",
+                            "type": "Type"
+                        },
+                        {
+                            "_label": "positional attributes",
+                            "id": "http://vocab.getty.edu/aat/300010269",
+                            "type": "Type"
+                        }
+                    ],
+                    "id": "https://staging-data.jpcarchive.org/object/00051151-f80c-4af6-bad2-65a0cb5e9b90/tile/d7453a2c-1a53-4c7a-9679-70724cba59c1/node/b6e12d04-7da0-11ee-90e1-5e9e1d6c824a",
+                    "type": "Dimension",
+                    "unit": {
+                        "_label": "numbers",
+                        "id": "http://vocab.getty.edu/aat/300055665",
+                        "type": "MeasurementUnit"
+                    },
+                    "value": 8
+                }
+            ],
+            "id": "https://staging-data.jpcarchive.org/object/00051151-f80c-4af6-bad2-65a0cb5e9b90/tile/d7453a2c-1a53-4c7a-9679-70724cba59c1/node/0eae4196-7d8a-11ee-b90f-5e9e1d6c824a",
+            "type": "AttributeAssignment",
+            "used_specific_object": [
+                {
+                    "_label": "Item order for urn:aspace:1c4d47e728a3fc5190c88b7f9909b811",
+                    "id": "https://staging-data.jpcarchive.org/object/00051151-f80c-4af6-bad2-65a0cb5e9b90/tile/d7453a2c-1a53-4c7a-9679-70724cba59c1/node/27cd9e14-7d8b-11ee-81da-aa5c27bfb039",
+                    "refers_to": [
+                        {
+                            "id": "https://staging-data.jpcarchive.org/object/00051151-f80c-4af6-bad2-65a0cb5e9b90/tile/d7453a2c-1a53-4c7a-9679-70724cba59c1/node/bd706ed6-8ef4-11ee-b71e-1a7b441944f3",
+                            "identified_by": [
+                                {
+                                    "content": "1c4d47e728a3fc5190c88b7f9909b811",
+                                    "id": "https://staging-data.jpcarchive.org/object/00051151-f80c-4af6-bad2-65a0cb5e9b90/tile/d7453a2c-1a53-4c7a-9679-70724cba59c1/node/48ff2508-8ef7-11ee-be03-aa5c27bfb039",
+                                    "type": "Identifier"
+                                }
+                            ],
+                            "type": "InformationObject"
+                        }
+                    ],
+                    "type": "Set"
+                }
+            ]
+        }
+    ],
+    "id": "https://staging-data.jpcarchive.org/object/00051151-f80c-4af6-bad2-65a0cb5e9b90",
+    "identified_by": [
+        {
+            "_label": "Primary Title",
+            "classified_as": [
+                {
+                    "_label": "titles (general, names)",
+                    "id": "http://vocab.getty.edu/aat/300417193",
+                    "type": "Type"
+                }
+            ],
+            "content": "Aiken, Kimberly - Box COI-001A Folder 047 Item 0008",
+            "id": "https://staging-data.jpcarchive.org/object/00051151-f80c-4af6-bad2-65a0cb5e9b90/tile/45824acb-f920-47db-a933-c0fcce94fd1c/node/0d074a56-7d88-11ee-81da-aa5c27bfb039",
+            "type": "Name"
+        },
+        {
+            "id": "https://staging-data.jpcarchive.org/object/00051151-f80c-4af6-bad2-65a0cb5e9b90/slug",
+            "type": "Identifier",
+            "content": "114PV0",
+            "classified_as": [
+                {
+                    "id": "https://data.getty.edu/local/thesaurus/temporary-slug",
+                    "type": "Type",
+                    "_label": "generated URL slug"
+                }
+            ]
+        }
+    ],
+    "type": "HumanMadeObject",
+    "part_of": [
+        {
+            "id": "https://staging-data.jpcarchive.org/component/1ff71b8c-1e3a-512b-a42c-7b1c4b0939e0",
+            "type": "InformationObject"
+        }
+    ],
+    "subject_of": [
+        {
+            "id": "https://iiif.jpcarchive.org/iiif/v2.0/manifest/arches:00051151-f80c-4af6-bad2-65a0cb5e9b90",
+            "type": "InformationObject",
+            "conforms_to": [
+                {
+                    "id": "http://iiif.io/api/presentation",
+                    "type": "InformationObject"
+                }
+            ],
+            "format": [
+                "application/ld+json;profile=\"http://iiif.io/api/presentation/2/context.json\""
+            ],
+            "classified_as": [
+                {
+                    "id": "https://data.getty.edu/local/thesaurus/iiif-manifest",
+                    "type": "Type",
+                    "_label": "IIIF manifest"
+                }
+            ]
+        }
+    ]
+}

--- a/src/helpers/LinkedArtHelpers.js
+++ b/src/helpers/LinkedArtHelpers.js
@@ -586,7 +586,7 @@ export function getAttributedBy(object, assignedProperty) {
  * an 'assigned_property' attribute that matches the assignedProperty parameter.
  *
  * @param {Object} object - the LinkedArt Object
- * @param {String} assignedProperty  - the assigned properly
+ * @param {String} assignedProperty  - the assigned properly (optional)
  * 
  * @example getAssignedBy(object, 'identified_by') would return the object with 'type': 'Name'
  * from the example object below
@@ -708,7 +708,7 @@ function _convertToArrayIfNeeded(resourceParam) {
  * Gets the assigned property objects
  *
  * @param {Array} assigned
- * @param {String} assignedProperty
+ * @param {String} assignedProperty (optional)
  * @private
  *
  * @returns {Array} - the assigned values
@@ -716,7 +716,10 @@ function _convertToArrayIfNeeded(resourceParam) {
 function _getAssignedProperty(assigned, assignedProperty) {
   let accumulator = [];
   assigned.forEach((attr) => {
-    if (attr[ASSIGNED_PROPERTY] == assignedProperty) {
+    if (
+      attr[ASSIGNED_PROPERTY] == assignedProperty ||
+      assignedProperty == undefined
+    ) {
       if (Array.isArray(attr[ASSIGNED])) {
         accumulator = accumulator.concat(attr[ASSIGNED]);
       } else {

--- a/src/helpers/LinkedArtHelpers.spec.js
+++ b/src/helpers/LinkedArtHelpers.spec.js
@@ -449,11 +449,10 @@ describe("get assigned", () => {
 
   it("tests an undefined assignment", () => {
     let assigned = helpers.getAssignedBy(jpc);
-    let values = assigned
-      .map((el) =>
-        getValueByClassification(el, "http://vocab.getty.edu/aat/300192339")
-      )
-      .filter((el) => el != null)[0];
+    let values = getValuesByClassification(
+      assigned,
+      "http://vocab.getty.edu/aat/300192339"
+    ).filter((el) => el != null)[0];
     expect(values).toEqual(8);
   });
 

--- a/src/helpers/LinkedArtHelpers.spec.js
+++ b/src/helpers/LinkedArtHelpers.spec.js
@@ -10,6 +10,7 @@ import irises from "../data/mocks/c88b3df0-de91-4f5b-a9ef-7b2b9a6d8abb";
 import titan from "../data/mocks/dff75e58-f8b9-4507-8ab7-5d948451dea7.json";
 import stagBeetle from "../data/mocks/a69d5696-70c2-56ed-9f82-fb2e69311e5d";
 import atticFragment from "../data/mocks/dd808888-4dfe-441c-b3d0-ce57c4167c5b";
+import jpc from "../data/mocks/jpc.json";
 
 let aat = {
   PREFERRED_TERM: "http://vocab.getty.edu/aat/300404670",
@@ -444,6 +445,16 @@ describe("get assigned", () => {
     expect(helpers.getAssignedBy(titan.produced_by, "part_of")[0].id).toEqual(
       "https://data.getty.edu/museum/collection/object/dff75e58-f8b9-4507-8ab7-5d948451dea7/production/previous-attribution/07ebbfca-985b-4a07-96ed-8cc7cf0c1ff1/production"
     );
+  });
+
+  it("tests an undefined assignment", () => {
+    let assigned = helpers.getAssignedBy(jpc);
+    let values = assigned
+      .map((el) =>
+        getValueByClassification(el, "http://vocab.getty.edu/aat/300192339")
+      )
+      .filter((el) => el != null)[0];
+    expect(values).toEqual(8);
   });
 
   it("gets the previously attributed artist (single)", () => {


### PR DESCRIPTION
`attributed_by` does not require an `assigned_property` so adjusting the logic to allow for it to be null. We need this for the JPC record modeling